### PR TITLE
Add global timezones and AUD/NZD currency support

### DIFF
--- a/app/(dashboard)/settings/settings-tabs.tsx
+++ b/app/(dashboard)/settings/settings-tabs.tsx
@@ -372,6 +372,8 @@ export function SettingsTabs({ business: initial, services: initServices, employ
 
   const CURRENCIES: { value: string; label: string }[] = [
     { value: 'USD', label: '🇺🇸 USD — US Dollar' },
+    { value: 'AUD', label: '🇦🇺 AUD — Australian Dollar' },
+    { value: 'NZD', label: '🇳🇿 NZD — New Zealand Dollar' },
     { value: 'EUR', label: '🇪🇺 EUR — Euro' },
     { value: 'GBP', label: '🇬🇧 GBP — British Pound' },
     { value: 'AED', label: '🇦🇪 AED — UAE Dirham' },
@@ -394,54 +396,48 @@ export function SettingsTabs({ business: initial, services: initServices, employ
   ]
 
   const isKnownCurrency = CURRENCIES.some((c) => c.value !== 'other' && c.value === biz.currency)
-  const currencySelectValue = isKnownCurrency ? biz.currency : (biz.currency ? 'other' : 'USD')
+  const [customCurrency, setCustomCurrency] = useState(!isKnownCurrency && !!biz.currency)
+  const currencySelectValue = customCurrency ? 'other' : (isKnownCurrency ? biz.currency : 'USD')
 
-  const TIMEZONES: { value: string; label: string }[] = [
-    { value: 'UTC',                    label: '(UTC+0) UTC' },
-    { value: 'Europe/London',          label: '(UTC+0) London' },
-    { value: 'Europe/Paris',           label: '(UTC+1) Paris' },
-    { value: 'Europe/Berlin',          label: '(UTC+1) Berlin' },
-    { value: 'Europe/Rome',            label: '(UTC+1) Rome' },
-    { value: 'Europe/Madrid',          label: '(UTC+1) Madrid' },
-    { value: 'Europe/Amsterdam',       label: '(UTC+1) Amsterdam' },
-    { value: 'Europe/Brussels',        label: '(UTC+1) Brussels' },
-    { value: 'Europe/Vienna',          label: '(UTC+1) Vienna' },
-    { value: 'Europe/Warsaw',          label: '(UTC+1) Warsaw' },
-    { value: 'Europe/Prague',          label: '(UTC+1) Prague' },
-    { value: 'Europe/Budapest',        label: '(UTC+1) Budapest' },
-    { value: 'Europe/Bucharest',       label: '(UTC+2) Bucharest' },
-    { value: 'Europe/Sofia',           label: '(UTC+2) Sofia' },
-    { value: 'Europe/Athens',          label: '(UTC+2) Athens' },
-    { value: 'Europe/Kiev',            label: '(UTC+2) Kyiv' },
-    { value: 'Europe/Minsk',           label: '(UTC+3) Minsk' },
-    { value: 'Europe/Moscow',          label: '(UTC+3) Moscow' },
-    { value: 'Europe/Istanbul',        label: '(UTC+3) Istanbul' },
-    { value: 'Asia/Dubai',             label: '(UTC+4) Dubai' },
-    { value: 'Asia/Karachi',           label: '(UTC+5) Karachi' },
-    { value: 'Asia/Kolkata',           label: '(UTC+5:30) Kolkata' },
-    { value: 'Asia/Dhaka',             label: '(UTC+6) Dhaka' },
-    { value: 'Asia/Bangkok',           label: '(UTC+7) Bangkok' },
-    { value: 'Asia/Singapore',         label: '(UTC+8) Singapore' },
-    { value: 'Asia/Shanghai',          label: '(UTC+8) Shanghai' },
-    { value: 'Asia/Tokyo',             label: '(UTC+9) Tokyo' },
-    { value: 'Asia/Seoul',             label: '(UTC+9) Seoul' },
-    { value: 'Australia/Sydney',       label: '(UTC+10) Sydney' },
-    { value: 'Australia/Melbourne',    label: '(UTC+10) Melbourne' },
-    { value: 'Pacific/Auckland',       label: '(UTC+12) Auckland' },
-    { value: 'America/New_York',       label: '(UTC-5) New York' },
-    { value: 'America/Toronto',        label: '(UTC-5) Toronto' },
-    { value: 'America/Chicago',        label: '(UTC-6) Chicago' },
-    { value: 'America/Mexico_City',    label: '(UTC-6) Mexico City' },
-    { value: 'America/Denver',         label: '(UTC-7) Denver' },
-    { value: 'America/Los_Angeles',    label: '(UTC-8) Los Angeles' },
-    { value: 'America/Vancouver',      label: '(UTC-8) Vancouver' },
-    { value: 'America/Anchorage',      label: '(UTC-9) Anchorage' },
-    { value: 'Pacific/Honolulu',       label: '(UTC-10) Honolulu' },
-    { value: 'America/Bogota',         label: '(UTC-5) Bogota' },
-    { value: 'America/Lima',           label: '(UTC-5) Lima' },
-    { value: 'America/Sao_Paulo',      label: '(UTC-3) São Paulo' },
-    { value: 'America/Buenos_Aires',   label: '(UTC-3) Buenos Aires' },
-  ]
+  const TIMEZONES: { value: string; label: string }[] = useMemo(() => {
+    const fallback = ['UTC']
+    const supported =
+      typeof Intl.supportedValuesOf === 'function'
+        ? Intl.supportedValuesOf('timeZone')
+        : fallback
+
+    const formatter = new Intl.DateTimeFormat('en', {
+      timeZoneName: 'shortOffset',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+
+    const offsetFor = (timeZone: string) => {
+      if (timeZone === 'UTC') return 'UTC+0'
+      try {
+        const parts = formatter.formatToParts(new Date())
+        const offset = new Intl.DateTimeFormat('en', {
+          timeZone,
+          timeZoneName: 'shortOffset',
+        })
+          .formatToParts(new Date())
+          .find((part) => part.type === 'timeZoneName')?.value
+
+        return offset?.replace('GMT', 'UTC') ?? 'UTC'
+      } catch {
+        return 'UTC'
+      }
+    }
+
+    const zones = supported.includes('UTC') ? supported : ['UTC', ...supported]
+
+    return zones
+      .map((value) => ({
+        value,
+        label: `(${offsetFor(value)}) ${value.replaceAll('_', ' ')}`,
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label))
+  }, [])
 
   const triggers = [
     t('notifications.triggers.confirmation'),
@@ -491,8 +487,13 @@ export function SettingsTabs({ business: initial, services: initServices, employ
               <label className="text-xs font-medium text-gray-500">{t('general.fields.currency')}</label>
               <select value={currencySelectValue}
                 onChange={(e) => {
-                  if (e.target.value !== 'other') setBiz((b) => ({ ...b, currency: e.target.value }))
-                  else setBiz((b) => ({ ...b, currency: '' }))
+                  if (e.target.value !== 'other') {
+                    setCustomCurrency(false)
+                    setBiz((b) => ({ ...b, currency: e.target.value }))
+                  } else {
+                    setCustomCurrency(true)
+                    setBiz((b) => ({ ...b, currency: '' }))
+                  }
                 }}
                 className="w-full mt-1 border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
                 {CURRENCIES.map((c) => (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1019,9 +1019,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1037,9 +1034,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1057,9 +1051,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1075,9 +1066,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1095,9 +1083,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1113,9 +1098,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1133,9 +1115,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1152,9 +1131,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1170,9 +1146,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1196,9 +1169,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1220,9 +1190,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1246,9 +1213,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1270,9 +1234,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1296,9 +1257,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1321,9 +1279,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1345,9 +1300,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1610,9 +1562,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1628,9 +1577,6 @@
       "integrity": "sha512-xIe1eujfHUB2XcxHGddxJyu6TJRPjC5NpIkQYB/32ESkt5VkQyIAjmLRS38c+s6QY+qjtY/4KarVDzXRuD7lZQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1648,9 +1594,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1666,9 +1609,6 @@
       "integrity": "sha512-TFBipb+gyesI/2Ve4zVu7kGltBWN/R466G5/1gtt2lECfc22G1pjkTxu68Q9aFcOaXiRGTQfvDbQQFe7mYgxiQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1878,9 +1818,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1900,9 +1837,6 @@
       "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1924,9 +1858,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1946,9 +1877,6 @@
       "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1970,9 +1898,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1992,9 +1917,6 @@
       "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3945,9 +3867,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3963,9 +3882,6 @@
       "integrity": "sha512-ZpF/pRe1guk6sKzQI9D1jAORtjTdNlyeXn9GDz8ophof/w2WhojRblvSDJaGe7rJjcPN8AaOkhwdRUh7q8oYIg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -3983,9 +3899,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4001,9 +3914,6 @@
       "integrity": "sha512-DLdJKVsJgglqQrJBuoUYNmzm3leI7kUZhLbZGHv42onfKsGf6JDS3+bzCUQfte/XOqDjh/tmmn1DR/CF/tCJFw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -4021,9 +3931,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4039,9 +3946,6 @@
       "integrity": "sha512-JHy3fMSc0t/EPWgo74+OK5TGr51aElnzqfUPaiRf2qJ/BfX5CUCfMiWVBuhI7qmVMBnk1jTRnL/xZnOSHDPLYg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -4598,9 +4502,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4615,9 +4516,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4632,9 +4530,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4649,9 +4544,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4666,9 +4558,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4683,9 +4572,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4700,9 +4586,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4717,9 +4600,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4734,9 +4614,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4751,9 +4628,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
## Summary

Improves Settings → General for international/self-hosted deployments.

### Changes
- Adds AUD — Australian Dollar
- Adds NZD — New Zealand Dollar
- Replaces the small hard-coded timezone list with runtime-supported IANA timezones
- Uses current timezone offsets rather than static offset labels, so DST is handled correctly
- Fixes the manual “Other” currency option so the custom currency input remains visible while entering a code

### Validation
- `npm install`
- `npm run build`
- Next.js 16.3.2 production build completed successfully, including TypeScript and static generation

The existing service-worker precache warning remains unchanged and is unrelated to these changes.