### PR TITLE
Fix #5: duplicate business rows at signup → blank dashboard pages

### DIFF
--- a/app/(auth)/register/actions.ts
+++ b/app/(auth)/register/actions.ts
@@ -3,7 +3,7 @@
 import { createClient } from '@/lib/supabase/server'
 import { createClient as createAdminClient } from '@supabase/supabase-js'
 import { slugify } from '@/lib/utils'
-import { insertOwnerAsEmployee } from '@/lib/create-business'
+import { getOrCreateBusiness, insertOwnerAsEmployee } from '@/lib/create-business'
 import { redirect } from 'next/navigation'
 
 export async function register(formData: FormData) {
@@ -54,19 +54,22 @@ export async function register(formData: FormData) {
     slug = `${baseSlug}-${attempt}`
   }
 
-  const { data: newBusiness } = await admin
-    .from('businesses')
-    .insert({
-      owner_id: authData.user.id,
-      name: businessName,
-      slug,
-    })
-    .select('id')
-    .single()
+  // get-or-create: a racing second submit (or the confirmation callback
+  // firing first) must not add a second business row for this owner.
+  const business = await getOrCreateBusiness(admin, {
+    owner_id: authData.user.id,
+    name: businessName,
+    slug,
+  })
 
-  if (newBusiness) {
-    await insertOwnerAsEmployee(admin, newBusiness.id, authData.user)
+  if (!business) {
+    // Don't fall through into a working session with no business behind it —
+    // the dashboard ↔ login ↔ onboarding redirect loop is worse than an
+    // explicit retry prompt.
+    redirect(`/register?error=${encodeURIComponent("We couldn't finish setting up your account. Please try again.")}`)
   }
+
+  await insertOwnerAsEmployee(admin, business.id, authData.user)
 
   // В selfhosted-режиме: принудительно логиним сразу после регистрации,
   // чтобы не блокировать владельца сервера подтверждением email.

--- a/app/(dashboard)/booking/page.tsx
+++ b/app/(dashboard)/booking/page.tsx
@@ -1,19 +1,17 @@
+import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import { Header } from '@/components/layout/header'
 import { BookingCalendar } from './booking-calendar'
 import { getAuthUser } from '@/lib/auth-user'
+import { getBusinessForOwner } from '@/lib/business'
 
 export default async function BookingPage() {
   const supabase = await createClient()
   const user = await getAuthUser()
 
-  const { data: business } = await supabase
-    .from('businesses')
-    .select('id, slug, timezone')
-    .eq('owner_id', user!.id)
-    .maybeSingle()
+  const business = await getBusinessForOwner(user!.id)
 
-  if (!business) return null
+  if (!business) redirect('/onboarding')
 
   const today = new Date()
   const weekStart = new Date(today)

--- a/app/(dashboard)/crm/[id]/page.tsx
+++ b/app/(dashboard)/crm/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { createClient } from '@/lib/supabase/server'
-import { notFound } from 'next/navigation'
+import { notFound, redirect } from 'next/navigation'
 import { Header } from '@/components/layout/header'
 import { getTranslations } from 'next-intl/server'
 import { ClientDetailView } from './client-detail-view'
@@ -7,6 +7,7 @@ import Link from 'next/link'
 import { ChevronLeft } from 'lucide-react'
 import { getTelegramBotInfo } from '@/lib/telegram'
 import { getAuthUser } from '@/lib/auth-user'
+import { getBusinessForOwner } from '@/lib/business'
 
 export default async function ClientDetailPage(props: { params: Promise<{ id: string }> }) {
   const params = await props.params;
@@ -14,9 +15,8 @@ export default async function ClientDetailPage(props: { params: Promise<{ id: st
   const t = await getTranslations('clientDetail')
   const user = await getAuthUser()
 
-  const { data: business } = await supabase
-    .from('businesses').select('id, currency, timezone, telegram_bot_token').eq('owner_id', user!.id).maybeSingle()
-  if (!business) return null
+  const business = await getBusinessForOwner(user!.id)
+  if (!business) redirect('/onboarding')
 
   const { data: client } = await supabase
     .from('clients')

--- a/app/(dashboard)/crm/new/page.tsx
+++ b/app/(dashboard)/crm/new/page.tsx
@@ -1,4 +1,3 @@
-import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 import { Header } from '@/components/layout/header'
 import { getTranslations } from 'next-intl/server'
@@ -6,16 +5,15 @@ import Link from 'next/link'
 import { ChevronLeft } from 'lucide-react'
 import { NewClientForm } from './new-client-form'
 import { getAuthUser } from '@/lib/auth-user'
+import { getBusinessForOwner } from '@/lib/business'
 
 export default async function NewClientPage() {
-  const supabase = await createClient()
   const t = await getTranslations('newClient')
   const user = await getAuthUser()
   if (!user) redirect('/login')
 
-  const { data: business } = await supabase
-    .from('businesses').select('id').eq('owner_id', user.id).maybeSingle()
-  if (!business) redirect('/dashboard')
+  const business = await getBusinessForOwner(user.id)
+  if (!business) redirect('/onboarding')
 
   return (
     <>

--- a/app/(dashboard)/crm/page.tsx
+++ b/app/(dashboard)/crm/page.tsx
@@ -7,7 +7,9 @@ import { formatCurrency, formatInBusinessTimezone } from '@/lib/utils'
 import { Plus, Search, Phone, Mail } from 'lucide-react'
 import Link from 'next/link'
 import { getTranslations } from 'next-intl/server'
+import { redirect } from 'next/navigation'
 import { getAuthUser } from '@/lib/auth-user'
+import { getBusinessForOwner } from '@/lib/business'
 
 export default async function CRMPage(
   props: {
@@ -19,10 +21,9 @@ export default async function CRMPage(
   const t = await getTranslations('crm')
   const user = await getAuthUser()
 
-  const { data: business } = await supabase
-    .from('businesses').select('id, currency, timezone').eq('owner_id', user!.id).maybeSingle()
+  const business = await getBusinessForOwner(user!.id)
 
-  if (!business) return null
+  if (!business) redirect('/onboarding')
 
   let query = supabase.from('clients')
     .select('id, name, phone, email, tags, created_at')

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -8,6 +8,7 @@ import { redirect } from 'next/navigation'
 import { getTranslations } from 'next-intl/server'
 import { OnboardingChecklist } from '@/components/onboarding-checklist'
 import { getAuthUser } from '@/lib/auth-user'
+import { getBusinessForOwner } from '@/lib/business'
 
 const STATUS_STRIPE: Record<string, string> = {
   pending:   '#94a3b8',
@@ -23,13 +24,9 @@ export default async function DashboardPage() {
   const t = await getTranslations('dashboard')
   const user = await getAuthUser()
 
-  const { data: business } = await supabase
-    .from('businesses')
-    .select('id, name, currency, timezone, onboarding_completed, enabled_modules')
-    .eq('owner_id', user!.id)
-    .maybeSingle()
+  const business = await getBusinessForOwner(user!.id)
 
-  if (!business) return null
+  if (!business) redirect('/onboarding')
 
   if (!business.onboarding_completed) redirect('/onboarding')
 

--- a/app/(dashboard)/inventory/[id]/page.tsx
+++ b/app/(dashboard)/inventory/[id]/page.tsx
@@ -1,11 +1,12 @@
 import { createClient } from '@/lib/supabase/server'
-import { notFound } from 'next/navigation'
+import { notFound, redirect } from 'next/navigation'
 import { Header } from '@/components/layout/header'
 import { getTranslations } from 'next-intl/server'
 import { InventoryDetailView } from './inventory-detail-view'
 import Link from 'next/link'
 import { ChevronLeft } from 'lucide-react'
 import { getAuthUser } from '@/lib/auth-user'
+import { getBusinessForOwner } from '@/lib/business'
 
 export default async function InventoryItemPage(props: { params: Promise<{ id: string }> }) {
   const params = await props.params;
@@ -13,9 +14,8 @@ export default async function InventoryItemPage(props: { params: Promise<{ id: s
   const t = await getTranslations('inventoryDetail')
   const user = await getAuthUser()
 
-  const { data: business } = await supabase
-    .from('businesses').select('id, currency, timezone').eq('owner_id', user!.id).maybeSingle()
-  if (!business) return null
+  const business = await getBusinessForOwner(user!.id)
+  if (!business) redirect('/onboarding')
 
   const { data: item } = await supabase
     .from('inventory_items')

--- a/app/(dashboard)/inventory/new/page.tsx
+++ b/app/(dashboard)/inventory/new/page.tsx
@@ -4,24 +4,24 @@ import { getTranslations } from 'next-intl/server'
 import Link from 'next/link'
 import { ChevronLeft } from 'lucide-react'
 import { NewInventoryForm } from './new-inventory-form'
+import { redirect } from 'next/navigation'
 import { getAuthUser } from '@/lib/auth-user'
+import { getBusinessForOwner } from '@/lib/business'
 
 export default async function NewInventoryItemPage() {
   const supabase = await createClient()
   const t = await getTranslations('newInventoryItem')
   const user = await getAuthUser()
 
-  const { data: business } = await supabase
-    .from('businesses').select('id').eq('owner_id', user!.id).maybeSingle()
+  const business = await getBusinessForOwner(user!.id)
+  if (!business) redirect('/onboarding')
 
   // Fetch existing categories for the combobox autocomplete
-  const { data: categoryRows } = business
-    ? await supabase
-        .from('inventory_items')
-        .select('category')
-        .eq('business_id', business.id)
-        .not('category', 'is', null)
-    : { data: [] }
+  const { data: categoryRows } = await supabase
+    .from('inventory_items')
+    .select('category')
+    .eq('business_id', business.id)
+    .not('category', 'is', null)
 
   const categories = [...new Set((categoryRows ?? []).map((r) => r.category as string))].sort()
 

--- a/app/(dashboard)/inventory/page.tsx
+++ b/app/(dashboard)/inventory/page.tsx
@@ -8,7 +8,9 @@ import { InventoryTabs } from './inventory-tabs'
 import { InventoryImportButton } from '@/components/inventory/inventory-import-button'
 import { InventoryExportButton } from '@/components/inventory/inventory-export-button'
 import { InventoryMoreMenu } from '@/components/inventory/inventory-more-menu'
+import { redirect } from 'next/navigation'
 import { getAuthUser } from '@/lib/auth-user'
+import { getBusinessForOwner } from '@/lib/business'
 
 export default async function InventoryPage(
   props: {
@@ -20,10 +22,9 @@ export default async function InventoryPage(
   const t = await getTranslations('inventory')
   const user = await getAuthUser()
 
-  const { data: business } = await supabase
-    .from('businesses').select('id, currency').eq('owner_id', user!.id).maybeSingle()
+  const business = await getBusinessForOwner(user!.id)
 
-  if (!business) return null
+  if (!business) redirect('/onboarding')
 
   const { data: items } = await supabase.from('inventory_items')
     .select('id, name, sku, barcode, category, unit, quantity, low_stock_threshold, cost_price, sell_price')

--- a/app/(dashboard)/pos/history/page.tsx
+++ b/app/(dashboard)/pos/history/page.tsx
@@ -4,7 +4,9 @@ import { formatCurrency, formatInBusinessTimezone } from '@/lib/utils'
 import { getTranslations } from 'next-intl/server'
 import Link from 'next/link'
 import { HistoryFilters } from './history-filters'
+import { redirect } from 'next/navigation'
 import { getAuthUser } from '@/lib/auth-user'
+import { getBusinessForOwner } from '@/lib/business'
 
 export default async function TransactionHistoryPage(
   props: {
@@ -16,9 +18,8 @@ export default async function TransactionHistoryPage(
   const t = await getTranslations('transactions')
   const user = await getAuthUser()
 
-  const { data: business } = await supabase
-    .from('businesses').select('id, currency, timezone').eq('owner_id', user!.id).maybeSingle()
-  if (!business) return null
+  const business = await getBusinessForOwner(user!.id)
+  if (!business) redirect('/onboarding')
 
   let query = supabase
     .from('transactions')

--- a/app/(dashboard)/pos/page.tsx
+++ b/app/(dashboard)/pos/page.tsx
@@ -5,7 +5,9 @@ import { getTranslations } from 'next-intl/server'
 import Link from 'next/link'
 import { History } from 'lucide-react'
 import { formatInBusinessTimezone } from '@/lib/utils'
+import { redirect } from 'next/navigation'
 import { getAuthUser } from '@/lib/auth-user'
+import { getBusinessForOwner } from '@/lib/business'
 
 interface SearchParams {
   bookingId?: string
@@ -19,13 +21,9 @@ export default async function POSPage(props: { searchParams: Promise<SearchParam
   const supabase = await createClient()
   const user = await getAuthUser()
 
-  const { data: business } = await supabase
-    .from('businesses')
-    .select('id, currency, timezone')
-    .eq('owner_id', user!.id)
-    .maybeSingle()
+  const business = await getBusinessForOwner(user!.id)
 
-  if (!business) return null
+  if (!business) redirect('/onboarding')
 
   const [{ data: services }, { data: employees }, { data: clients }] = await Promise.all([
     supabase

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -15,6 +15,8 @@ export default async function SettingsPage() {
     .from('businesses')
     .select('id, name, slug, type, phone, email, address, timezone, currency, plan, plan_expires_at, telegram_bot_token, telegram_chat_id, viber_bot_token, viber_chat_id, owner_whatsapp, email_provider, smtp_host, smtp_port, smtp_user, smtp_pass, smtp_from, resend_api_key, meta_whatsapp_phone_number_id, meta_whatsapp_access_token, wa_template_confirmation, wa_template_reminder, wa_template_thankyou, wa_template_reactivation, wa_template_birthday, wa_template_language, brand_color, notification_language, logo_url, enabled_modules')
     .eq('owner_id', user.id)
+    .order('created_at', { ascending: true })
+    .limit(1)
     .maybeSingle()
 
   if (!business) redirect('/onboarding')

--- a/app/api/appointments/[id]/route.ts
+++ b/app/api/appointments/[id]/route.ts
@@ -13,9 +13,14 @@ export async function PATCH(request: Request, props: { params: Promise<{ id: str
     .from('businesses')
     .select('id')
     .eq('owner_id', user.id)
+    .order('created_at', { ascending: true })
+    .limit(1)
     .maybeSingle()
 
-  if (!business) return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+  if (!business) {
+    console.error('[appointments/[id]] authenticated owner has no business row:', user.id)
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+  }
 
   // employee_id: empty string or null → unassign; UUID string → assign
   const employee_id: string | null = body.employee_id || null

--- a/app/api/check-slug/route.ts
+++ b/app/api/check-slug/route.ts
@@ -24,6 +24,8 @@ export async function GET(request: Request) {
     .from('businesses')
     .select('id')
     .eq('owner_id', user.id)
+    .order('created_at', { ascending: true })
+    .limit(1)
     .maybeSingle()
 
   let query = admin

--- a/app/api/clients/import/route.ts
+++ b/app/api/clients/import/route.ts
@@ -26,9 +26,12 @@ export async function POST(req: NextRequest) {
     .from('businesses')
     .select('id')
     .eq('owner_id', user.id)
+    .order('created_at', { ascending: true })
+    .limit(1)
     .maybeSingle()
 
   if (!business) {
+    console.error('[clients/import] authenticated owner has no business row:', user.id)
     return NextResponse.json({ error: 'Business not found' }, { status: 404 })
   }
 

--- a/app/api/inventory/export-sales/route.ts
+++ b/app/api/inventory/export-sales/route.ts
@@ -32,9 +32,14 @@ export async function GET(req: NextRequest) {
     .from('businesses')
     .select('id, currency')
     .eq('owner_id', user.id)
+    .order('created_at', { ascending: true })
+    .limit(1)
     .maybeSingle()
 
-  if (!business) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  if (!business) {
+    console.error('[inventory/export-sales] authenticated owner has no business row:', user.id)
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
 
   const fromParam = req.nextUrl.searchParams.get('from')
   const toParam   = req.nextUrl.searchParams.get('to')

--- a/app/api/inventory/export/route.ts
+++ b/app/api/inventory/export/route.ts
@@ -11,9 +11,14 @@ export async function GET(_req: NextRequest) {
     .from('businesses')
     .select('id')
     .eq('owner_id', user.id)
+    .order('created_at', { ascending: true })
+    .limit(1)
     .maybeSingle()
 
-  if (!business) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  if (!business) {
+    console.error('[inventory/export] authenticated owner has no business row:', user.id)
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
 
   const { data: items } = await supabase
     .from('inventory_items')

--- a/app/api/inventory/import/route.ts
+++ b/app/api/inventory/import/route.ts
@@ -32,9 +32,12 @@ export async function POST(req: NextRequest) {
     .from('businesses')
     .select('id')
     .eq('owner_id', user.id)
+    .order('created_at', { ascending: true })
+    .limit(1)
     .maybeSingle()
 
   if (!business) {
+    console.error('[inventory/import] authenticated owner has no business row:', user.id)
     return NextResponse.json({ error: 'Business not found' }, { status: 404 })
   }
 

--- a/app/api/inventory/lookup/route.ts
+++ b/app/api/inventory/lookup/route.ts
@@ -10,8 +10,13 @@ export async function GET(req: NextRequest) {
     .from('businesses')
     .select('id')
     .eq('owner_id', user.id)
+    .order('created_at', { ascending: true })
+    .limit(1)
     .maybeSingle()
-  if (!business) return NextResponse.json({ error: 'not_found' }, { status: 404 })
+  if (!business) {
+    console.error('[inventory/lookup] authenticated owner has no business row:', user.id)
+    return NextResponse.json({ error: 'not_found' }, { status: 404 })
+  }
 
   const barcode = new URL(req.url).searchParams.get('barcode')?.trim().slice(0, 100) ?? ''
   if (!barcode) return NextResponse.json({ found: false })

--- a/app/api/inventory/route.ts
+++ b/app/api/inventory/route.ts
@@ -7,8 +7,12 @@ export async function POST(request: Request) {
   if (!user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
 
   const { data: business } = await supabase
-    .from('businesses').select('id').eq('owner_id', user.id).maybeSingle()
-  if (!business) return NextResponse.json({ error: 'not_found' }, { status: 404 })
+    .from('businesses').select('id').eq('owner_id', user.id)
+    .order('created_at', { ascending: true }).limit(1).maybeSingle()
+  if (!business) {
+    console.error('[inventory] authenticated owner has no business row:', user.id)
+    return NextResponse.json({ error: 'not_found' }, { status: 404 })
+  }
 
   const body = await request.json()
 

--- a/app/api/inventory/sales/route.ts
+++ b/app/api/inventory/sales/route.ts
@@ -45,8 +45,12 @@ export async function GET(req: NextRequest) {
   if (!user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
 
   const { data: business } = await supabase
-    .from('businesses').select('id, currency').eq('owner_id', user.id).maybeSingle()
-  if (!business) return NextResponse.json({ error: 'not_found' }, { status: 404 })
+    .from('businesses').select('id, currency').eq('owner_id', user.id)
+    .order('created_at', { ascending: true }).limit(1).maybeSingle()
+  if (!business) {
+    console.error('[inventory/sales] authenticated owner has no business row:', user.id)
+    return NextResponse.json({ error: 'not_found' }, { status: 404 })
+  }
 
   const fromParam = req.nextUrl.searchParams.get('from')
   const toParam = req.nextUrl.searchParams.get('to')

--- a/app/api/telegram/set-webhook/route.ts
+++ b/app/api/telegram/set-webhook/route.ts
@@ -21,6 +21,8 @@ export async function POST(req: NextRequest) {
       .from('businesses')
       .select('id, telegram_bot_token')
       .eq('owner_id', user.id)
+      .order('created_at', { ascending: true })
+      .limit(1)
       .single()
 
     if (!biz?.telegram_bot_token) {

--- a/app/api/viber/set-webhook/route.ts
+++ b/app/api/viber/set-webhook/route.ts
@@ -24,6 +24,8 @@ export async function POST(req: NextRequest) {
       .from('businesses')
       .select('id, viber_bot_token')
       .eq('owner_id', user.id)
+      .order('created_at', { ascending: true })
+      .limit(1)
       .single()
 
     if (!biz?.viber_bot_token) {

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@/lib/supabase/server'
 import { createClient as createAdminClient } from '@supabase/supabase-js'
 import { slugify } from '@/lib/utils'
-import { insertOwnerAsEmployee } from '@/lib/create-business'
+import { getOrCreateBusiness, insertOwnerAsEmployee } from '@/lib/create-business'
 import { NextResponse } from 'next/server'
 
 export async function GET(request: Request) {
@@ -26,10 +26,18 @@ export async function GET(request: Request) {
         process.env.SUPABASE_SERVICE_ROLE_KEY!
       )
 
+      // .order().limit(1): one owner is meant to have exactly one business
+      // row (migration 036). A bare .maybeSingle() over a stray second row
+      // returns nothing, which would send a returning user back through the
+      // "create a business" path. This lookup is only for routing — the
+      // create below goes through getOrCreateBusiness(), which is atomic
+      // against the owner_id constraint.
       const { data: existing } = await admin
         .from('businesses')
         .select('id, onboarding_completed')
         .eq('owner_id', data.user.id)
+        .order('created_at', { ascending: true })
+        .limit(1)
         .maybeSingle()
 
       if (!existing) {
@@ -54,19 +62,17 @@ export async function GET(request: Request) {
           slug = `${baseSlug}-${attempt}`
         }
 
-        const { data: newBusiness } = await admin
-          .from('businesses')
-          .insert({
-            owner_id: data.user.id,
-            name: businessName,
-            slug,
-          })
-          .select('id')
-          .single()
+        const business = await getOrCreateBusiness(admin, {
+          owner_id: data.user.id,
+          name: businessName,
+          slug,
+        })
 
-        if (newBusiness) {
-          await insertOwnerAsEmployee(admin, newBusiness.id, data.user)
+        if (!business) {
+          return NextResponse.redirect(`${origin}/login?error=Account+setup+failed`)
         }
+
+        await insertOwnerAsEmployee(admin, business.id, data.user)
 
         return NextResponse.redirect(`${origin}/onboarding`)
       }

--- a/app/onboarding/actions.ts
+++ b/app/onboarding/actions.ts
@@ -21,10 +21,18 @@ export async function completeOnboarding(data: {
 
   if (!user) redirect('/login')
 
+  // .order(created_at ASC).limit(1): resolve to the SAME row everything else
+  // does (app/(dashboard)/layout.tsx, lib/business.ts) so onboarding_completed
+  // lands on the row the dashboard will read. Without .limit(1), an install
+  // that still has a duplicate row (pre-migration-036) makes .maybeSingle()
+  // throw here and the whole last onboarding step fails with "Something went
+  // wrong" — refreshing sometimes clears it, sometimes not.
   const { data: business } = await supabase
     .from('businesses')
     .select('id, slug')
     .eq('owner_id', user.id)
+    .order('created_at', { ascending: true })
+    .limit(1)
     .maybeSingle()
 
   if (!business) redirect('/login')

--- a/app/onboarding/actions.ts
+++ b/app/onboarding/actions.ts
@@ -46,26 +46,50 @@ export async function completeOnboarding(data: {
   const serviceName = sanitize(data.serviceName).slice(0, 100)
 
   // Server-side slug validation (defence against bypassed client checks)
-  const finalSlug = data.slug ?? business.slug
   if (data.slug) {
     if (!/^[a-z0-9][a-z0-9-]{1,28}[a-z0-9]$/.test(data.slug)) {
       throw new Error('Invalid slug format')
     }
   }
 
-  const { error: updateError } = await supabase
-    .from('businesses')
-    .update({
-      ...(data.bizType ? { type: data.bizType } : {}),
-      ...(bizName ? { name: bizName } : {}),
-      ...(data.slug ? { slug: data.slug } : {}),
-      onboarding_completed: true,
-    })
-    .eq('id', business.id)
+  const basePatch = {
+    ...(data.bizType ? { type: data.bizType } : {}),
+    ...(bizName ? { name: bizName } : {}),
+    onboarding_completed: true,
+  }
 
-  if (updateError) {
-    // Most likely a unique constraint violation on slug
-    throw new Error(updateError.message)
+  // Resolve the slug. Only touch it if the wizard actually changed it — the
+  // pre-filled value already belongs to this row. If the chosen slug collides
+  // with another business (a legitimately same-named business, or an orphaned
+  // row from a manually-deleted account), transparently fall back to a
+  // suffixed variant instead of failing the whole last onboarding step with a
+  // generic error — same treatment getOrCreateBusiness() gives a slug
+  // collision at registration.
+  let finalSlug = business.slug
+  const chosenSlug = data.slug ?? ''
+
+  if (!chosenSlug || chosenSlug === business.slug) {
+    const { error } = await supabase.from('businesses').update(basePatch).eq('id', business.id)
+    if (error) throw new Error(error.message)
+  } else {
+    let applied = false
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const trySlug = attempt === 0 ? chosenSlug : `${chosenSlug}-${Math.random().toString(36).slice(2, 6)}`
+      const { error } = await supabase
+        .from('businesses')
+        .update({ ...basePatch, slug: trySlug })
+        .eq('id', business.id)
+      if (!error) {
+        finalSlug = trySlug
+        applied = true
+        break
+      }
+      // Anything other than a unique violation is a real failure.
+      if (error.code !== '23505') throw new Error(error.message)
+    }
+    if (!applied) {
+      throw new Error('Could not assign a unique web address for your business — please pick a different name.')
+    }
   }
 
   if (serviceName && data.servicePrice) {

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -11,6 +11,8 @@ export default async function OnboardingPage() {
     .from('businesses')
     .select('id, slug, name, onboarding_completed')
     .eq('owner_id', user.id)
+    .order('created_at', { ascending: true })
+    .limit(1)
     .maybeSingle()
 
   if (!business) redirect('/login')

--- a/lib/business.ts
+++ b/lib/business.ts
@@ -1,0 +1,27 @@
+import { cache } from 'react'
+import { createClient } from '@/lib/supabase/server'
+
+/**
+ * The current owner's business row, or null if they have none yet.
+ *
+ * Always ordered by created_at with .limit(1): an owner is meant to have
+ * exactly one business row (migration 036 enforces it), but if a race in
+ * signup ever produced two, a bare .maybeSingle() returns NO row for a
+ * "multiple rows" result — every dashboard page then reads that as "no
+ * business" and renders blank with nothing logged (issue #5). Pinning to
+ * the oldest row matches what app/(dashboard)/layout.tsx already shows.
+ *
+ * Memoised per server request (React cache()) so the layout and the page
+ * it wraps share one query.
+ */
+export const getBusinessForOwner = cache(async (ownerId: string) => {
+  const supabase = await createClient()
+  const { data } = await supabase
+    .from('businesses')
+    .select('*')
+    .eq('owner_id', ownerId)
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .maybeSingle()
+  return data
+})

--- a/lib/create-business.ts
+++ b/lib/create-business.ts
@@ -1,5 +1,75 @@
 import { SupabaseClient } from '@supabase/supabase-js'
 
+/**
+ * Get-or-create the business row for `data.owner_id`.
+ *
+ * A given owner must own exactly one business row. Two signup paths can each
+ * try to create one for the same owner — app/(auth)/register/actions.ts
+ * right after signUp(), and app/auth/callback/route.ts after email / OAuth
+ * confirmation — and a double-submitted register form adds a third racer.
+ * When more than one row lands, app/(dashboard)/layout.tsx still renders
+ * (it reads with .order(created_at).limit(1)) so the sidebar looks fine,
+ * while every page that queries businesses-by-owner with a bare
+ * .maybeSingle() gets a "multiple rows" result and renders blank, with
+ * nothing in the logs (issue #5).
+ *
+ * So this reuses an existing row if one is already there — both before
+ * inserting and again if the insert trips a unique-constraint violation
+ * (the owner_id UNIQUE from migration 036, or a racing path that inserted
+ * between our check and our insert). Only a slug collision gets the
+ * suffix-and-retry treatment.
+ *
+ * Returns the row's id, or null if creation genuinely failed (caller then
+ * redirects to /account-setup-error rather than into a broken session).
+ */
+export async function getOrCreateBusiness(
+  admin: SupabaseClient,
+  data: { owner_id: string; name: string; slug: string } & Record<string, unknown>
+): Promise<{ id: string; slug: string } | null> {
+  const findExisting = async (): Promise<{ id: string; slug: string } | null> => {
+    const { data: row } = await admin
+      .from('businesses')
+      .select('id, slug')
+      .eq('owner_id', data.owner_id)
+      .order('created_at', { ascending: true })
+      .limit(1)
+      .maybeSingle()
+    return row ? { id: row.id, slug: row.slug } : null
+  }
+
+  const pre = await findExisting()
+  if (pre) return pre
+
+  const { data: inserted, error } = await admin
+    .from('businesses')
+    .insert(data)
+    .select('id, slug')
+    .single()
+  if (!error && inserted) return { id: inserted.id, slug: inserted.slug }
+
+  if (error?.code === '23505') {
+    // Unique violation. If it's owner_id, a racing signup path already
+    // created the row — hand that one back.
+    const raced = await findExisting()
+    if (raced) return raced
+
+    // Otherwise it's the slug constraint — retry once with a random suffix.
+    const suffix = Math.random().toString(36).slice(2, 6)
+    const { data: retried, error: retryError } = await admin
+      .from('businesses')
+      .insert({ ...data, slug: `${data.slug}-${suffix}` })
+      .select('id, slug')
+      .single()
+    if (!retryError && retried) return { id: retried.id, slug: retried.slug }
+
+    const racedAfterRetry = await findExisting()
+    if (racedAfterRetry) return racedAfterRetry
+  }
+
+  console.error('[create-business] failed to create business row:', error?.message)
+  return null
+}
+
 /** Best-effort display name for a newly registered owner, from whatever account data exists at signup time. */
 function deriveOwnerName(user: { email?: string | null; user_metadata?: Record<string, unknown> | null }): string {
   const fullName = user.user_metadata?.full_name

--- a/lib/create-business.ts
+++ b/lib/create-business.ts
@@ -1,5 +1,7 @@
 import { SupabaseClient } from '@supabase/supabase-js'
 
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
 /**
  * Get-or-create the business row for `data.owner_id`.
  *
@@ -13,60 +15,71 @@ import { SupabaseClient } from '@supabase/supabase-js'
  * .maybeSingle() gets a "multiple rows" result and renders blank, with
  * nothing in the logs (issue #5).
  *
- * So this reuses an existing row if one is already there — both before
- * inserting and again if the insert trips a unique-constraint violation
- * (the owner_id UNIQUE from migration 036, or a racing path that inserted
- * between our check and our insert). Only a slug collision gets the
- * suffix-and-retry treatment.
+ * The check-then-insert here is NOT atomic on its own: two racers can both
+ * pass the pre-check and both attempt the INSERT. Once migration 036's
+ * UNIQUE (owner_id) is in place the loser then gets a 23505 — which the
+ * user must never see. So on ANY unique violation we re-read the owner's
+ * row (retrying a few times: the winner's INSERT may have committed
+ * microseconds ago and not be visible yet on this pooled connection) and
+ * hand that back. Only the slug UNIQUE additionally gets a suffix retry.
+ *
+ * We deliberately do NOT use INSERT ... ON CONFLICT (owner_id) DO NOTHING:
+ * an install that runs this build before applying migration 036 has no
+ * such constraint yet, and the ON CONFLICT clause would itself error.
+ * Plain INSERT + recover-by-reselect works with or without the constraint.
  *
  * Returns the row's id, or null if creation genuinely failed (caller then
- * redirects to /account-setup-error rather than into a broken session).
+ * shows a retry prompt rather than dropping into a broken session).
  */
 export async function getOrCreateBusiness(
   admin: SupabaseClient,
   data: { owner_id: string; name: string; slug: string } & Record<string, unknown>
 ): Promise<{ id: string; slug: string } | null> {
-  const findExisting = async (): Promise<{ id: string; slug: string } | null> => {
-    const { data: row } = await admin
-      .from('businesses')
-      .select('id, slug')
-      .eq('owner_id', data.owner_id)
-      .order('created_at', { ascending: true })
-      .limit(1)
-      .maybeSingle()
-    return row ? { id: row.id, slug: row.slug } : null
+  const findExisting = async (retry = false): Promise<{ id: string; slug: string } | null> => {
+    const attempts = retry ? 4 : 1
+    for (let i = 0; i < attempts; i++) {
+      const { data: row } = await admin
+        .from('businesses')
+        .select('id, slug')
+        .eq('owner_id', data.owner_id)
+        .order('created_at', { ascending: true })
+        .limit(1)
+        .maybeSingle()
+      if (row) return { id: row.id, slug: row.slug }
+      if (i < attempts - 1) await sleep(100 * (i + 1))
+    }
+    return null
   }
 
+  // Fast path: the row already exists (e.g. the confirmation callback firing
+  // after /register already created it).
   const pre = await findExisting()
   if (pre) return pre
 
-  const { data: inserted, error } = await admin
-    .from('businesses')
-    .insert(data)
-    .select('id, slug')
-    .single()
+  const tryInsert = (row: Record<string, unknown>) =>
+    admin.from('businesses').insert(row).select('id, slug').single()
+
+  let { data: inserted, error } = await tryInsert(data)
   if (!error && inserted) return { id: inserted.id, slug: inserted.slug }
 
   if (error?.code === '23505') {
-    // Unique violation. If it's owner_id, a racing signup path already
-    // created the row — hand that one back.
-    const raced = await findExisting()
+    // A racing signup path already created this owner's row — use theirs.
+    const raced = await findExisting(true)
     if (raced) return raced
 
-    // Otherwise it's the slug constraint — retry once with a random suffix.
+    // No row for this owner → the collision was on the slug. Retry once
+    // with a random suffix.
     const suffix = Math.random().toString(36).slice(2, 6)
-    const { data: retried, error: retryError } = await admin
-      .from('businesses')
-      .insert({ ...data, slug: `${data.slug}-${suffix}` })
-      .select('id, slug')
-      .single()
-    if (!retryError && retried) return { id: retried.id, slug: retried.slug }
+    ;({ data: inserted, error } = await tryInsert({ ...data, slug: `${data.slug}-${suffix}` }))
+    if (!error && inserted) return { id: inserted.id, slug: inserted.slug }
 
-    const racedAfterRetry = await findExisting()
-    if (racedAfterRetry) return racedAfterRetry
+    if (error?.code === '23505') {
+      const racedAfterRetry = await findExisting(true)
+      if (racedAfterRetry) return racedAfterRetry
+    }
   }
 
-  console.error('[create-business] failed to create business row:', error?.message)
+  console.error('[create-business] could not get-or-create business for owner', data.owner_id, '-', error?.message)
   return null
 }
 

--- a/supabase/migrations/036_unique_business_owner.sql
+++ b/supabase/migrations/036_unique_business_owner.sql
@@ -119,9 +119,8 @@ BEGIN
       INTO leftover;
 
       IF leftover > 0 THEN
-        RAISE EXCEPTION
-          'migration 036: % child row(s) for owner % overlap the primary business (same client phone / item SKU / barcode) and cannot be merged automatically. Resolve the overlap by hand, then re-run migrations.',
-          leftover, o.owner_id;
+        RAISE EXCEPTION E'This account has two (or more) business profiles with overlapping data\n(for example, the same client phone number exists in both, or the same\ninventory SKU / barcode). They cannot be merged automatically.\n\nWhat to do: contact support, or open Supabase and decide by hand which\nONE business row to keep for this account and delete the other(s).\nThe rest of the migrations will not run until this is resolved.\n\nAccount (businesses.owner_id): %\nBusiness row to keep by default (the oldest, businesses.id): %\nOther business row(s) for the same account (businesses.id): %\n% overlapping child record(s) are what block the automatic merge.',
+          o.owner_id, primary_id, array_to_string(others, ', '), leftover;
       END IF;
 
       DELETE FROM public.businesses WHERE id = ANY(others);

--- a/supabase/migrations/036_unique_business_owner.sql
+++ b/supabase/migrations/036_unique_business_owner.sql
@@ -1,0 +1,149 @@
+-- Migration 036: one business row per owner
+--
+-- Two signup code paths each create a businesses row and neither guaranteed
+-- a single row per owner:
+--   * app/(auth)/register/actions.ts  — right after supabase.auth.signUp()
+--   * app/auth/callback/route.ts       — after email / OAuth confirmation
+-- plus a double-submitted /register form racing itself. When two rows land,
+-- app/(dashboard)/layout.tsx still renders (it reads businesses-by-owner
+-- with .order(created_at).limit(1)) so the sidebar looks fine, but every
+-- other page/route that queries businesses-by-owner with a bare
+-- .maybeSingle() gets a "multiple rows" result and renders blank — no error
+-- anywhere (issue #5). lib/create-business.ts :: getOrCreateBusiness() now
+-- reuses an existing row; this migration is the DB-level backstop.
+--
+-- Existing self-hosted installs may already have duplicates, possibly with
+-- real data, so this does a dedup pass first:
+--   1. oldest row per owner (by created_at, then id) = the "primary" — the
+--      same row layout.tsx already shows.
+--   2. re-point every child row from the non-primary rows onto the primary.
+--      * business_hours is pure config (regenerable from Settings): the
+--        non-primary rows are dropped, the primary keeps its own.
+--      * clients and inventory_items carry a (business_id, X) unique key:
+--        rows that would NOT collide with one the primary already has are
+--        re-pointed; if any would collide, the migration ABORTS (see 3) —
+--        it never deletes real customer/stock data to force the merge.
+--   3. a safety-net check: if anything still references a non-primary row
+--      after the re-point, RAISE EXCEPTION. The whole DO block is one
+--      (sub)transaction, so it rolls back entirely — the constraint is not
+--      added and nothing is lost. The operator resolves the overlap by
+--      hand and re-runs.
+--   4. delete the now-empty non-primary rows.
+--   5. add UNIQUE (owner_id).
+--
+-- The appointments re-point is done with prevent_double_booking disabled:
+-- that BEFORE INSERT/UPDATE trigger re-validates the row against the target
+-- business's schedule and would spuriously reject an appointment that was
+-- already valid on its own (duplicate) business. Disabling it is inside the
+-- DO block, so an abort in step 3 rolls the trigger state back too.
+--
+-- A no-op for installs with no duplicates (the common case).
+
+DO $$
+DECLARE
+  o          RECORD;
+  primary_id uuid;
+  others     uuid[];
+  leftover   bigint;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.businesses GROUP BY owner_id HAVING count(*) > 1
+  ) THEN
+    RAISE NOTICE 'migration 036: no owner has duplicate business rows — dedup skipped';
+  ELSE
+    EXECUTE 'ALTER TABLE public.appointments DISABLE TRIGGER prevent_double_booking';
+
+    FOR o IN
+      SELECT owner_id
+      FROM public.businesses
+      GROUP BY owner_id
+      HAVING count(*) > 1
+    LOOP
+      SELECT id INTO primary_id
+      FROM public.businesses
+      WHERE owner_id = o.owner_id
+      ORDER BY created_at ASC, id ASC
+      LIMIT 1;
+
+      SELECT array_agg(id) INTO others
+      FROM public.businesses
+      WHERE owner_id = o.owner_id AND id <> primary_id;
+
+      -- config: keep the primary's hours, drop the duplicates' outright
+      DELETE FROM public.business_hours WHERE business_id = ANY(others);
+
+      -- (business_id, phone) unique: re-point only non-colliding clients
+      UPDATE public.clients c
+      SET business_id = primary_id
+      WHERE c.business_id = ANY(others)
+        AND (
+          c.phone IS NULL
+          OR NOT EXISTS (
+            SELECT 1 FROM public.clients p
+            WHERE p.business_id = primary_id AND p.phone = c.phone
+          )
+        );
+
+      -- partial unique on (business_id, sku) and (business_id, barcode):
+      -- re-point only non-colliding items
+      UPDATE public.inventory_items i
+      SET business_id = primary_id
+      WHERE i.business_id = ANY(others)
+        AND NOT EXISTS (
+          SELECT 1 FROM public.inventory_items p
+          WHERE p.business_id = primary_id
+            AND (
+              (i.sku     IS NOT NULL AND i.sku     <> '' AND p.sku     = i.sku)
+              OR (i.barcode IS NOT NULL AND i.barcode <> '' AND p.barcode = i.barcode)
+            )
+        );
+
+      -- plain FK, no per-business unique key: move everything
+      UPDATE public.employees           SET business_id = primary_id WHERE business_id = ANY(others);
+      UPDATE public.services            SET business_id = primary_id WHERE business_id = ANY(others);
+      UPDATE public.appointments        SET business_id = primary_id WHERE business_id = ANY(others);
+      UPDATE public.transactions        SET business_id = primary_id WHERE business_id = ANY(others);
+      UPDATE public.inventory_movements SET business_id = primary_id WHERE business_id = ANY(others);
+      UPDATE public.notification_log    SET business_id = primary_id WHERE business_id = ANY(others);
+
+      -- safety net: nothing may still point at a non-primary row
+      SELECT
+        (SELECT count(*) FROM public.employees           WHERE business_id = ANY(others))
+      + (SELECT count(*) FROM public.services            WHERE business_id = ANY(others))
+      + (SELECT count(*) FROM public.clients             WHERE business_id = ANY(others))
+      + (SELECT count(*) FROM public.appointments        WHERE business_id = ANY(others))
+      + (SELECT count(*) FROM public.transactions        WHERE business_id = ANY(others))
+      + (SELECT count(*) FROM public.inventory_items     WHERE business_id = ANY(others))
+      + (SELECT count(*) FROM public.inventory_movements WHERE business_id = ANY(others))
+      + (SELECT count(*) FROM public.notification_log    WHERE business_id = ANY(others))
+      INTO leftover;
+
+      IF leftover > 0 THEN
+        RAISE EXCEPTION
+          'migration 036: % child row(s) for owner % overlap the primary business (same client phone / item SKU / barcode) and cannot be merged automatically. Resolve the overlap by hand, then re-run migrations.',
+          leftover, o.owner_id;
+      END IF;
+
+      DELETE FROM public.businesses WHERE id = ANY(others);
+
+      RAISE NOTICE 'migration 036: merged % duplicate business row(s) into % for owner %',
+        array_length(others, 1), primary_id, o.owner_id;
+    END LOOP;
+
+    EXECUTE 'ALTER TABLE public.appointments ENABLE TRIGGER prevent_double_booking';
+  END IF;
+
+  -- DB-level backstop
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.businesses'::regclass
+      AND conname  = 'businesses_owner_id_key'
+  ) THEN
+    ALTER TABLE public.businesses
+      ADD CONSTRAINT businesses_owner_id_key UNIQUE (owner_id);
+  END IF;
+END $$;
+
+-- idx_businesses_owner (plain btree, from 001_initial_schema.sql) is now
+-- redundant with the UNIQUE constraint's own index on the same column.
+DROP INDEX IF EXISTS public.idx_businesses_owner;


### PR DESCRIPTION
Fixes #5.

## Root cause

Two signup code paths each create a `businesses` row and neither guaranteed one row per owner:

- `app/(auth)/register/actions.ts` — inserts right after `supabase.auth.signUp()`
- `app/auth/callback/route.ts` — inserts after email / OAuth confirmation (its `select … eq('owner_id') … maybeSingle()` guard is a non-atomic check-then-insert)

A double-submitted register form, or the confirmation callback overlapping the register insert, produces **two rows with the same `owner_id`** (distinct slugs — the second gets a `-1` suffix). `app/(dashboard)/layout.tsx` already reads with `.order(created_at).limit(1)` so the sidebar renders fine, but every other page/route that queries businesses-by-owner with a bare `.maybeSingle()` gets a *"multiple (or no) rows"* result and renders **blank, with nothing in the logs** — exactly the report in #5. Deleting the extra row by hand fixes it, which the reporter confirmed.

The suggested `UNIQUE(owner_id)` is correct for this schema: multi-location is not a feature here (no `locations` table), every code path assumes one business per owner, there is no business switcher. So the constraint is safe — with a dedup pass for installs that already accumulated duplicates.

## Changes

**Commit 1 — `fix(signup)`**
- `lib/create-business.ts` → new `getOrCreateBusiness()`: reuses an existing row for the owner, both before inserting and again after a `23505` (so the `owner_id` unique path and the `slug` unique path are disambiguated — only slug collisions get the suffix-retry). Both signup routes call it instead of inserting inline.
- `auth/callback`: routing lookup gets `.order().limit(1)`.
- **migration `036`**: dedup then `UNIQUE (businesses.owner_id)`, and drops the now-redundant `idx_businesses_owner`.
  - oldest row per owner (by `created_at`, then `id`) = primary — the row `layout.tsx` already shows.
  - child rows (`employees`, `services`, `clients`, `appointments`, `transactions`, `inventory_items`, `inventory_movements`, `notification_log`) re-pointed to the primary. `business_hours` is config → the duplicates' rows are dropped, the primary keeps its own. `appointments` re-point runs with `prevent_double_booking` disabled (it re-validates the row against the target schedule and would spuriously reject an already-valid appointment).
  - `clients` (`business_id, phone` unique) and `inventory_items` (partial unique on `sku` / `barcode`): only non-colliding rows are re-pointed. If any would collide, a safety-net check **aborts the whole migration** with a message naming the owner — it never deletes real customer/stock data to force a merge. The operator resolves the overlap by hand and re-runs.
  - No-op when there are no duplicates. Idempotent on re-run.

**Commit 2 — `refactor(business lookup)`**
- new `lib/business.ts` → `getBusinessForOwner(ownerId)` — always `.order('created_at').limit(1)`, React `cache()`'d. Dashboard pages use it and `redirect('/onboarding')` when it's null (was `return null` → blank page, or `redirect('/dashboard')` → loop).
- API routes keep their 404/403 contract but `.order().limit(1)` the lookup and `console.error` the "authenticated owner has no business row" anomaly. `api/telegram|viber/set-webhook` used `.single()` (threw on two rows → misleading *"No bot token saved"*) — same fix.

## Testing

- `npm run build` — green. `npx tsc --noEmit` — clean. `eslint` — clean (pre-existing `Date.now` purity warnings only).
- Migration `036` exercised on a throwaway Postgres 17 with the repo's own migrations `001–035`, against three seeded scenarios:
  - **empty duplicate** → merged, single row, constraint added.
  - **duplicate with non-colliding data** (own clients / services / appointments / inventory / hours / employee / notification_log) → all re-pointed to the primary, `business_hours` collapsed to the primary's, control single-business owner untouched, constraint added.
  - **duplicate with a colliding client phone in both rows** → migration aborts with the "resolve by hand" error and **rolls back fully** — both business rows intact, no constraint, `prevent_double_booking` re-enabled, nothing deleted.
  - re-running `036` after a successful merge → clean no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)