### PR TITLE
fix(onboarding): re-throw the redirect that ends completeOnboarding()

### DIFF
--- a/app/onboarding/OnboardingWizard.tsx
+++ b/app/onboarding/OnboardingWizard.tsx
@@ -137,7 +137,22 @@ export function OnboardingWizard({ initialSlug, initialName, isSaas, rootDomain 
         serviceDuration: showDuration ? (Number(service.duration_min) || 60) : 0,
         ...(isSaas ? { slug } : {}),
       })
-    } catch {
+    } catch (err) {
+      // completeOnboarding() ends in redirect() (to the tenant subdomain in
+      // SaaS mode — an external URL). Next resolves that by REJECTING this
+      // action promise with a redirect error (digest "NEXT_REDIRECT;…") so
+      // <RedirectBoundary> can navigate. A bare `catch` swallows it and shows
+      // a spurious error even though the DB write and the redirect have
+      // already happened. Re-throw redirect errors so the navigation
+      // completes; only surface a real failure (and log the actual cause).
+      if (
+        err && typeof err === 'object' && 'digest' in err &&
+        typeof (err as { digest?: unknown }).digest === 'string' &&
+        (err as { digest: string }).digest.startsWith('NEXT_REDIRECT')
+      ) {
+        throw err
+      }
+      console.error('[onboarding] finish() failed:', err)
       setError(t('step2.error'))
       setSaving(false)
     }


### PR DESCRIPTION
`completeOnboarding()` ends with `redirect()`. For an external target (the tenant subdomain in SaaS mode) Next resolves the server-action redirect by **rejecting** the action promise with a redirect error (digest `NEXT_REDIRECT;…`) so `<RedirectBoundary>` can navigate — see `next/dist/client/components/router-reducer/reducers/server-action-reducer.js` (`isExternalURL` → `reject(redirectError)` + `completeHardNavigation`).

`OnboardingWizard.finish()` had `try { await completeOnboarding(…) } catch { setError(t('step2.error')) }`, which swallowed that reject and showed "Something went wrong" on the last onboarding step even though the DB write (`onboarding_completed = true`) and the navigation had already happened — deterministic, first-attempt, "fixed" by a reload.

`finish()` now re-throws any error whose `digest` starts with `"NEXT_REDIRECT"` so the navigation completes, and `console.error`s the real object for anything else before showing the generic message. Worst case: identical UX to today plus the real cause in the console.

`tsc` ✅ · `eslint` ✅ · `next build` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)