### PR TITLE
fix: add missing /api/business/logo route (Supabase Storage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,9 @@ Open http://localhost:3000
 2. Copy your **Database connection string** (Session mode, port 5432) from  
    **Project Settings → Database → Connection string** and set it as `DATABASE_URL` in `.env`  
    Migrations are applied automatically when you run `docker-compose up`
-3. Create a public storage bucket named **`inventory`** in  
-   **Supabase Dashboard → Storage → New bucket** (required for product photos)
+3. Create two **public** storage buckets in **Supabase Dashboard → Storage → New bucket**:
+   - **`inventory`** — required for product photos
+   - **`logos`** — required for the business logo upload (Settings → General)
 4. Copy your project URL and anon/service keys to `.env`
 5. **Customize email templates** (optional) — replace Supabase's defaults with Pronto-branded HTML:
 
@@ -174,7 +175,7 @@ Messenger credentials (Telegram, WhatsApp, Viber) are configured per-business in
 | Backend | Next.js API Routes |
 | Database | Supabase (PostgreSQL) with RLS |
 | Auth | Supabase Auth (Email + Google OAuth) |
-| Storage | Supabase Storage (product photos) |
+| Storage | Supabase Storage (product photos, business logos) |
 | Notifications | Resend/SMTP + Telegram Bot API + Meta WhatsApp Cloud API + Viber Bot API |
 | i18n | next-intl — EN / ES / PT |
 | Deployment | Docker Compose |

--- a/app/api/business/logo/route.ts
+++ b/app/api/business/logo/route.ts
@@ -1,0 +1,170 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { createServiceClient } from '@/lib/supabase/service'
+import { getBusinessForOwner } from '@/lib/business'
+
+// Business logo upload for self-hosted installs.
+//
+// Storage backend is Supabase Storage — same convention as product photos
+// (see app/api/inventory/[id]/photo/route.ts). The operator must create a
+// public bucket named `logos` (Supabase Dashboard → Storage → New bucket);
+// this is documented in README.md next to the `inventory` bucket step.
+
+const BUCKET = 'logos'
+
+const ALLOWED_TYPES: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/webp': 'webp',
+  'image/svg+xml': 'svg',
+}
+const MAX_SIZE = 2 * 1024 * 1024 // 2MB
+
+// Recover the storage object key from a stored public URL so the previous
+// file can be cleaned up. Public URLs look like
+//   <base>/storage/v1/object/public/logos/<businessId>/<file>
+function keyFromPublicUrl(url: string): string | null {
+  const marker = `/storage/v1/object/public/${BUCKET}/`
+  const i = url.indexOf(marker)
+  if (i === -1) return null
+  const key = url.slice(i + marker.length)
+  return key.length > 0 ? key : null
+}
+
+// ── POST — upload logo ───────────────────────────────────────────────────────
+
+export async function POST(req: NextRequest) {
+  try {
+    const supabase = await createClient()
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const business = await getBusinessForOwner(user.id)
+    if (!business) {
+      return NextResponse.json({ error: 'Business not found' }, { status: 404 })
+    }
+
+    let formData: FormData
+    try {
+      formData = await req.formData()
+    } catch {
+      return NextResponse.json({ error: 'Invalid form data' }, { status: 400 })
+    }
+
+    const file = formData.get('logo')
+    if (!(file instanceof File)) {
+      return NextResponse.json(
+        { error: 'No file provided (field name must be "logo")' },
+        { status: 400 },
+      )
+    }
+
+    const ext = ALLOWED_TYPES[file.type]
+    if (!ext) {
+      return NextResponse.json(
+        { error: `Invalid file type "${file.type}". Allowed: PNG, JPG, WebP, SVG` },
+        { status: 400 },
+      )
+    }
+
+    if (file.size > MAX_SIZE) {
+      return NextResponse.json({ error: 'File too large. Maximum size is 2MB' }, { status: 400 })
+    }
+
+    const admin = createServiceClient()
+    const key = `${business.id}/${Date.now()}.${ext}`
+    const buffer = Buffer.from(await file.arrayBuffer())
+
+    const { error: uploadError } = await admin.storage
+      .from(BUCKET)
+      .upload(key, buffer, { contentType: file.type, upsert: true })
+
+    if (uploadError) {
+      console.error('[business/logo POST] storage upload error:', uploadError.message)
+      return NextResponse.json(
+        {
+          error:
+            `Upload failed: ${uploadError.message}. ` +
+            `Make sure a public Storage bucket named "${BUCKET}" exists in your Supabase project.`,
+        },
+        { status: 500 },
+      )
+    }
+
+    const { data: { publicUrl } } = admin.storage.from(BUCKET).getPublicUrl(key)
+
+    const { error: updateError } = await supabase
+      .from('businesses')
+      .update({ logo_url: publicUrl })
+      .eq('id', business.id)
+
+    if (updateError) {
+      console.error('[business/logo POST] businesses update error:', updateError.message)
+      return NextResponse.json({ error: `DB error: ${updateError.message}` }, { status: 500 })
+    }
+
+    // Best-effort: drop the previously stored file so the bucket doesn't grow
+    // unbounded. Never fail the request on a cleanup error.
+    if (business.logo_url) {
+      const oldKey = keyFromPublicUrl(business.logo_url)
+      if (oldKey && oldKey !== key) {
+        try {
+          await admin.storage.from(BUCKET).remove([oldKey])
+        } catch {
+          /* ignore cleanup failure */
+        }
+      }
+    }
+
+    return NextResponse.json({ logo_url: publicUrl })
+  } catch (err) {
+    // Global safety net — always return JSON, never let Next.js fall through
+    // to its default HTML/text error response for this route.
+    const msg = err instanceof Error ? err.message : String(err)
+    console.error('[business/logo POST] unhandled error:', msg)
+    return NextResponse.json({ error: `Server error: ${msg}` }, { status: 500 })
+  }
+}
+
+// ── DELETE — remove logo ─────────────────────────────────────────────────────
+
+export async function DELETE() {
+  try {
+    const supabase = await createClient()
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const business = await getBusinessForOwner(user.id)
+    if (!business) {
+      return NextResponse.json({ error: 'Business not found' }, { status: 404 })
+    }
+
+    if (business.logo_url) {
+      const oldKey = keyFromPublicUrl(business.logo_url)
+      if (oldKey) {
+        try {
+          const admin = createServiceClient()
+          await admin.storage.from(BUCKET).remove([oldKey])
+        } catch {
+          /* ignore cleanup failure */
+        }
+      }
+    }
+
+    const { error: updateError } = await supabase
+      .from('businesses')
+      .update({ logo_url: null })
+      .eq('id', business.id)
+
+    if (updateError) {
+      console.error('[business/logo DELETE] businesses update error:', updateError.message)
+      return NextResponse.json({ error: `DB error: ${updateError.message}` }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    console.error('[business/logo DELETE] unhandled error:', msg)
+    return NextResponse.json({ error: `Server error: ${msg}` }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Problem

Self-hosted users get an instant **HTTP 500 / `Internal Server Error`** when uploading a logo in **Settings → General** (issue #7).

The logo UI in `app/(dashboard)/settings/settings-tabs.tsx` (`uploadLogo()` / `removeLogo()`) calls `POST` / `DELETE /api/business/logo`, and `settings/page.tsx` already selects `logo_url` — but **the route handler was never ported to this repo**. `app/api/business/` only contains `modules/route.ts`.

### Why 500 and not a normal 404

A `POST` to an unmatched App Router path does **not** get Next's plain-text 404 short-circuit (that branch is `GET`/`HEAD` only — `next/dist/server/lib/router-server.js`). Next instead renders the not-found route through the root `app/layout.tsx`; this repo has no `not-found.tsx` / `error.tsx`, and when that error-page render also fails Next's last resort is `res.end('Internal Server Error')` with status 500. So the reporter's instinct ("looks like an unhandled exception, not just a wrong path") was right — it's Next's own error-render path bottoming out, not our code.

## Fix

Add `app/api/business/logo/route.ts`, modelled on the existing `app/api/inventory/[id]/photo/route.ts`:

- **Supabase Storage backend** (new public bucket `logos`) — *not* the Cloudflare R2 implementation used in the hosted build. Self-hosted must not require a Cloudflare account.
- **No `subscription_tier` gate** — self-hosted has no paid tiers; the feature is available to everyone.
- Owner auth via `getBusinessForOwner()`; the `businesses.logo_url` write goes through the RLS client, Storage upload + previous-file cleanup through the service client.
- **Global `try/catch` that always returns JSON** — a missing/misconfigured bucket now surfaces a readable error (`... Make sure a public Storage bucket named "logos" exists ...`) instead of the bare 500. This also removes the bare-500 symptom for this route specifically.

`README.md`: document creating the `logos` bucket next to the existing `inventory` bucket step, and update the Tech Stack "Storage" row.

## Scope / testing

Purely additive — one new route + docs, nothing existing changes.

- `npx tsc --noEmit` — clean
- `npm run lint` (new file) — clean
- `npm run build` — succeeds; `/api/business/logo` now registered as a dynamic route
- Manual logo upload on a local self-hosted stand — pending maintainer verification (requires creating the `logos` bucket)

## Follow-up (not in this PR)

Any uncaught `POST` to a non-existent path in this repo yields a useless bare 500 because there's no `app/not-found.tsx` / `app/global-error.tsx` and the root layout's `next-intl` calls aren't resilient to error-page renders. Worth hardening separately; does not block this fix.

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)