### PR TITLE
fix: readable 404s for unmatched routes instead of a bare 500

### DIFF
--- a/app/api/[...unmatched]/route.ts
+++ b/app/api/[...unmatched]/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+
+// Catch-all for any request under /api/* that has no matching route handler.
+// Without this, a non-GET request (POST especially) to an unknown /api path
+// falls through to Next's HTML not-found render — and when that render fails it
+// degrades to a bare "Internal Server Error". Exact and dynamic route matches
+// always take precedence over this catch-all, so real endpoints are unaffected.
+// (issue #15)
+
+export const dynamic = 'force-dynamic'
+
+function handler() {
+  return NextResponse.json({ error: 'Not found' }, { status: 404 })
+}
+
+export const GET = handler
+export const POST = handler
+export const PUT = handler
+export const PATCH = handler
+export const DELETE = handler
+export const OPTIONS = handler
+export const HEAD = handler

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+// Last-resort boundary: catches errors thrown while rendering the root layout
+// itself. By Next.js convention it REPLACES the root layout, so it must render
+// its own <html>/<body> and cannot rely on anything the layout provides
+// (fonts, next-intl, globals.css). Active in production builds only. (issue #15)
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  if (process.env.NODE_ENV !== 'production') {
+    console.error('[global-error]', error)
+  }
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          minHeight: '100dvh',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: '0.75rem',
+          padding: '2rem',
+          textAlign: 'center',
+          fontFamily:
+            'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+          color: '#0f172a',
+          background: '#fff',
+        }}
+      >
+        <h1 style={{ fontSize: '1.125rem', fontWeight: 600, margin: 0 }}>Something went wrong</h1>
+        <p style={{ margin: 0, color: '#64748b', maxWidth: '28rem' }}>
+          An unexpected error occurred. Try again, or head back to the homepage.
+        </p>
+        <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.5rem' }}>
+          <button
+            type="button"
+            onClick={() => reset()}
+            style={{
+              borderRadius: '0.5rem',
+              background: '#16a34a',
+              color: '#fff',
+              padding: '0.5rem 1rem',
+              fontWeight: 500,
+              border: 'none',
+              cursor: 'pointer',
+            }}
+          >
+            Try again
+          </button>
+          {/*
+            Plain <a>, not next/link: global-error replaces the root layout, so
+            the Next router context it needs is not guaranteed to be mounted.
+            This matches Next's own global-error examples.
+          */}
+          {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+          <a
+            href="/"
+            style={{
+              borderRadius: '0.5rem',
+              border: '1px solid #cbd5e1',
+              color: '#0f172a',
+              padding: '0.5rem 1rem',
+              fontWeight: 500,
+              textDecoration: 'none',
+            }}
+          >
+            Go to homepage
+          </a>
+        </div>
+      </body>
+    </html>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,12 @@ import type { Metadata, Viewport } from 'next'
 import { Inter } from 'next/font/google'
 import { NextIntlClientProvider } from 'next-intl'
 import { getLocale, getMessages } from 'next-intl/server'
+import enMessages from '../messages/en.json'
 import './globals.css'
+
+// English fallback used only when the request-scoped next-intl config is
+// unavailable (see RootLayout below).
+const FALLBACK_MESSAGES = enMessages as Awaited<ReturnType<typeof getMessages>>
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -57,13 +62,24 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode
 }) {
-  const locale = await getLocale()
-  const messages = await getMessages()
+  // getLocale() / getMessages() read the request-scoped next-intl config. While
+  // Next renders an error page (a not-found, or an exception bubbling to the
+  // root) that scope can be missing and these throw — which would take the
+  // error page down with it, leaving Next to emit a bare "Internal Server
+  // Error". Degrade to English so the layout always renders. (issue #15)
+  let locale = 'en'
+  let messages = FALLBACK_MESSAGES
+  try {
+    locale = await getLocale()
+    messages = await getMessages()
+  } catch (err) {
+    console.error('[RootLayout] next-intl request config unavailable, falling back to en:', err)
+  }
 
   return (
     <html lang={locale}>
       <body className={inter.className}>
-        <NextIntlClientProvider messages={messages}>
+        <NextIntlClientProvider locale={locale} messages={messages}>
           {children}
         </NextIntlClientProvider>
       </body>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,46 @@
+import Link from 'next/link'
+
+// Rendered for unmatched routes and explicit notFound() calls. Deliberately
+// dependency-free (no next-intl, no data fetching) so it renders even when the
+// thing that broke is the app's i18n or data layer. It still mounts inside the
+// root layout, which is hardened to never throw. (issue #15)
+export default function NotFound() {
+  return (
+    <main
+      style={{
+        minHeight: '100dvh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: '0.75rem',
+        padding: '2rem',
+        textAlign: 'center',
+        fontFamily:
+          'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+        color: '#0f172a',
+      }}
+    >
+      <p style={{ fontSize: '2.5rem', fontWeight: 700, margin: 0 }}>404</p>
+      <h1 style={{ fontSize: '1.125rem', fontWeight: 600, margin: 0 }}>Page not found</h1>
+      <p style={{ margin: 0, color: '#64748b', maxWidth: '28rem' }}>
+        The page you&rsquo;re looking for doesn&rsquo;t exist or may have moved.
+      </p>
+      <Link
+        href="/"
+        style={{
+          marginTop: '0.5rem',
+          display: 'inline-block',
+          borderRadius: '0.5rem',
+          background: '#16a34a',
+          color: '#fff',
+          padding: '0.5rem 1rem',
+          fontWeight: 500,
+          textDecoration: 'none',
+        }}
+      >
+        Go to homepage
+      </Link>
+    </main>
+  )
+}


### PR DESCRIPTION
Fixes #15.

## Problem

A non-`GET` request (a `POST` especially) to a path with no route handler returned an opaque **`500` / `Internal Server Error`** (plain text). Chain: Next renders the not-found route through the root layout → `app/layout.tsx` calls `getLocale()` / `getMessages()` unconditionally → during an error-page render that request-scoped next-intl config can be missing and those throw → the error page itself blows up → Next falls back to the bare text response. This is what made #7 hard to diagnose.

## Fix — four independent layers

| Layer | Closes |
|---|---|
| **`app/layout.tsx`** — wrap the next-intl calls in `try/catch` with an English fallback (`locale 'en'` + `messages/en.json`) | The root layout — and every error page rendered through it — can no longer throw here. This is the core fix. |
| **`app/not-found.tsx`** — dependency-free 404 page (no next-intl, no data), link home | Unknown non-API paths get a real page instead of a crash |
| **`app/global-error.tsx`** — self-contained (`'use client'`, own `<html>`/`<body>`, per Next convention), production-only | Last resort if the root layout itself throws |
| **`app/api/[...unmatched]/route.ts`** — catch-all for every method under `/api/*`, returns `{ error: "Not found" }` / 404 in the same shape as other API routes | Unknown `/api` paths get consistent JSON for every method, never the HTML not-found render |

### Block 1 answers

- **`global-error.tsx` vs `not-found.tsx` re: layout.** Confirmed for Next 16.3.2: `not-found.tsx` renders *inside* the root layout, so on its own it does **not** help when the layout is the thing throwing — hence layer 1 is required. `global-error.tsx` *replaces* the root layout and must bring its own `<html>`/`<body>`; it's the only boundary that survives a root-layout crash, so it's written self-contained (no fonts, no next-intl, no `globals.css`) and uses a plain `<a href="/">` (no router context guaranteed).
- **Catch-all precedence.** Verified at runtime, not assumed — real routes are untouched (see below). Next resolves exact and dynamic (`[id]`) matches before the catch-all.

## Verification — `next start` against the production build

| Request | Result | Meaning |
|---|---|---|
| `GET /api/health` | `200 {"status":"ok"}` | real route |
| `POST /api/business/modules` | `405` | real route (only exports `PATCH`) — catch-all does **not** intercept |
| `POST /api/business/logo` | `401 {"error":"Unauthorized"}` | real route runs |
| `GET /api/inventory/lookup` | `401 {"error":"unauthorized"}` | real route runs |
| `POST /api/nonexistent-endpoint` | `404 {"error":"Not found"}` | **was a bare 500** |
| `GET /api/nonexistent-endpoint` | `404 {"error":"Not found"}` | consistent JSON |
| `DELETE /api/some/deep/fake/path` | `404 {"error":"Not found"}` | **was a bare 500** |
| `POST /totally-fake-page` | `404` + not-found HTML | **was a bare 500** |
| `GET /this-page-does-not-exist` | `404` + not-found HTML | custom page renders inside the hardened layout |

- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npm run build` — succeeds; `/api/[...unmatched]` and `/_not-found` registered, all real API routes still present

## Scope

Additive: one changed file (`layout.tsx`, +try/catch), three new files. No behavior change for any route that already existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)